### PR TITLE
Fix env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This is a simple backend skeleton for a Computerized Adaptive Testing (CAT) appl
 
 ## Getting Started
 
-Install dependencies and start the development server. Ensure PostgreSQL is
-running and `DATABASE_URL` is configured:
+Install dependencies and start the development server. Environment variables can
+be placed in a `.env` file at the project root. Ensure PostgreSQL is running and
+`DATABASE_URL` is configured:
 
 ```bash
 npm install
@@ -49,7 +50,7 @@ The `users` table now stores extended profile information such as `username`,
 
 ## Configuration
 
-Before starting the server, set the `DATABASE_URL` environment variable to point to your PostgreSQL instance. The connection string format is:
+Before starting the server, set the following environment variables or create a `.env` file with these values. At minimum, `DATABASE_URL` should point to your PostgreSQL instance. The connection string format is:
 
 ```
 postgres://<username>:<password>@<host>:<port>/<database>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.8",
+        "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.2",
@@ -244,6 +245,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "commonjs",
   "dependencies": {
     "amqplib": "^0.10.8",
+    "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const app = express();
 const routes = require('./routes');


### PR DESCRIPTION
## Summary
- load environment variables via `dotenv` in `src/index.js`
- document `.env` usage in README
- add `dotenv` dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854e893982c8327b2526f36149add2d